### PR TITLE
Bug fix in basedialog.py

### DIFF
--- a/manatools/ui/basedialog.py
+++ b/manatools/ui/basedialog.py
@@ -73,7 +73,7 @@ class BaseDialog :
     self._timeout = 0
     self._minSize = None
     if minWidth > 0 and minHeight > 0 :
-      self._minSize = { 'minHeight' : minHeight, 'minWidth' : minHeight}
+      self._minSize = { 'minHeight' : minHeight, 'minWidth' : minWidth}
 
   @property 
   def running(self):


### PR DESCRIPTION
In the initialisation of the basedialog class, minWidth is set at the min height. That's why it is not possible to create a new ui with a min height different of the min width.

I just fix this bug. 