### PR TITLE
Fix filter for askForExistingFile to Qt format. Add generic filter too.

### DIFF
--- a/manatools/aui/yui_qt.py
+++ b/manatools/aui/yui_qt.py
@@ -265,7 +265,8 @@ class YApplicationQt:
         """
         try:
             start = startWith or ""
-            flt = filter if filter else "All files (*)"
+            flt = filter.replace(";", " ") + ";;;All files (*)" if filter else "All files (*)"
+            
             fn, _ = QtWidgets.QFileDialog.getOpenFileName(None, headline or "Open File", start, flt)
             return fn or ""
         except Exception:


### PR DESCRIPTION
Filter should be semi-column separated. However, Qt does not read directly this format.
Furthermore, "All files" option should also be added.
Here, we replace semi-column with space. When added, "All files (*)" is adde separated with ";;;".